### PR TITLE
Improve performance

### DIFF
--- a/src/guessers/guessers.cpp
+++ b/src/guessers/guessers.cpp
@@ -94,9 +94,9 @@ void Guesser::run()
     SysUtils::Watch watch;
 	int32_t n = 0, numBlocks = 0;
 
-	Memblock blocks[8];
+	Memblock blocks[CHUNK_SIZE];
 	while (!abortFlag()) {
-		for (numBlocks = 0; numBlocks < 8; numBlocks++) {
+		for (numBlocks = 0; numBlocks < CHUNK_SIZE; numBlocks++) {
 			if (!guess(&blocks[numBlocks])) {
 				break;
 			}
@@ -118,7 +118,7 @@ void Guesser::run()
 			n = 0;
 		}
 
-		if (numBlocks != 8) {
+		if (numBlocks != CHUNK_SIZE) {
 			Attack::exhausted();
 			break;
 		}

--- a/src/guessers/guessers.h
+++ b/src/guessers/guessers.h
@@ -46,6 +46,8 @@ namespace Guessers
 
 class Guesser : public SysUtils::Thread
 {
+	static int const CHUNK_SIZE = 128;
+
 	public:
 		Guesser(Buffer *buffer);
 		virtual ~Guesser() { }

--- a/src/tester.cpp
+++ b/src/tester.cpp
@@ -66,10 +66,10 @@ void Tester::run()
 	}
 
 	uint32_t numBlocks = 0;
-	Memblock blocks[8];
+	Memblock blocks[CHUNK_SIZE];
 
 	while (!abortFlag()) {
-		numBlocks = m_buffer->taken(8, blocks);
+		numBlocks = m_buffer->taken(CHUNK_SIZE, blocks);
 
 		for (uint32_t i = 0; i < numBlocks; i++) {
 			if (blocks[i].length > 0 && check(blocks[i])) {

--- a/src/tester.h
+++ b/src/tester.h
@@ -35,6 +35,8 @@ class Buffer;
 
 class Tester : public SysUtils::Thread
 {
+	static int const CHUNK_SIZE = 128;
+
 	public:
 		Tester(const Key &key, Buffer *buffer);
 		~Tester();


### PR DESCRIPTION
Two small changes that improve performance for me.

The first change reduces thread-switching by increasing the number of memory blocks read and written from the inter-thread buffer from 8 at a time to 128. With 4 threads on a 4-core system, this increases throughput from 600k/s to around 6m/s for me.

The second change gives another small boost by separately locking writing and reading to and from the inter-thread buffer.
